### PR TITLE
Make loki find the bucket when AWS is used

### DIFF
--- a/contrib/deploy_functions.sh
+++ b/contrib/deploy_functions.sh
@@ -112,6 +112,7 @@ loki:
         request_timeout: 2m
       aws:
         s3: ${s3_endpoint}
+        region: us-east-1
         s3forcepathstyle: true
         http_config:
           insecure_skip_verify: true


### PR DESCRIPTION
@eranra I had to add `region: us-east-1` to loki's config to make loki find the bucket when I created the bucket on AWS (on IBM COS this wasn't needed).
Do you want me leave it hardcoded, or should I extract it as a parameter?